### PR TITLE
Cast `Mesh2_face_nodes` attribute `start_index` to an integer

### DIFF
--- a/scripts/download_austen.py
+++ b/scripts/download_austen.py
@@ -44,6 +44,11 @@ dataset = xr.Dataset(
     },
     attrs=dataset.attrs,
 )
+# This connectivity array has a string-typed start_index.
+# This goes against the spec, and raises a warning in emsarray.
+# Let's fix it here so our example datasets are well formed.
+face_nodes = dataset['Mesh2_face_nodes']
+face_nodes.attrs['start_index'] = np.int32(face_nodes.attrs['start_index'])
 
 if out.exists():
     out.unlink()


### PR DESCRIPTION
This attribute should not be a string. Support has been added to emsarray for this being a string, but it emits a warning. The example datasets should be good examples rather than broken examples. See csiro-coasts/emsarray/pull/26