### PR TITLE
Consistently use K'gari over Fraser Island

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,16 +33,16 @@ Link
 Licence
     `CC BY 4.0 <https://creativecommons.org/licenses/by/4.0/>`_
 
-``fraser``
+``kgari``
 ========
 
 A subset of the Great Barrier Reef 4km (GBR4) v2.0 model,
 part of the eReefs data.
-This subset is centred around K'gari / Fraser Island.
+This subset is centred around K'gari.
 This dataset is defined on a curvilinear grid with two dimensional coordinates,
 handled by the ``CFGrid2D`` convention.
 Temperature, sea surface height, and current variables are included.
-The dataset is downloaded and subset via the ``scripts/download_fraser.py`` script.
+The dataset is downloaded and subset via the ``scripts/download_kgari.py`` script.
 
 Link
     https://research.csiro.au/ereefs/ereefs-data/

--- a/scripts/download_kgari.py
+++ b/scripts/download_kgari.py
@@ -8,7 +8,7 @@ import emsarray
 from emsarray.utils import extract_vars
 
 url = "https://thredds.nci.org.au/thredds/dodsC/fx3/gbr4_v2/gbr4_simple_2022-05-12.nc"
-out = pathlib.Path("./fraser.nc")
+out = pathlib.Path("./kgari.nc")
 
 dataset = emsarray.open_dataset(url)
 


### PR DESCRIPTION
The name was officially changed in 2023, about time we did the same.

This will also need updating in the tutorials, notebooks, etc.